### PR TITLE
Food detail page

### DIFF
--- a/Besteats/FoodDetail/ViewController/FoodDetailViewController.swift
+++ b/Besteats/FoodDetail/ViewController/FoodDetailViewController.swift
@@ -30,7 +30,6 @@ class FoodDetailTableViewCell: UITableViewCell {
     
     lazy var favoriteButton: UIButton = {
         let button = UIButton()
-//        button.
         return button
     }()
     
@@ -68,11 +67,11 @@ class FoodDetailViewController: UIViewController {
     var type: String = "like"
     
     private let selectedItem: String
-//    private let relatedItems: [String]
+    private let relatedItems: FoodModiModel
     
-    init(selectedItem: String) {
+    init(selectedItem: String, relatedItems: FoodModiModel) {
         self.selectedItem = selectedItem
-//        self.relatedItems = relatedItems
+        self.relatedItems = relatedItems
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -122,7 +121,8 @@ class FoodDetailViewController: UIViewController {
     
     lazy var foodDetailTableView: UITableView = {
         let tableView = UITableView()
-        tableView.register(FoodDetailTableViewCell.self, forCellReuseIdentifier: FoodDetailTableViewCell.identifier)
+        tableView.register(FoodDetailTableViewCell.self,
+                           forCellReuseIdentifier: FoodDetailTableViewCell.identifier)
         return tableView
     }()
     
@@ -139,8 +139,13 @@ class FoodDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "BM JUA_OTF", size: 20)!]
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가", style: .plain, target: self, action: #selector(addTapped))
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가",
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(addTapped))
         title = selectedItem
         
         view.backgroundColor = .brown
@@ -152,6 +157,7 @@ class FoodDetailViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         setUpTableView()
+        
     }
     
     // MARK: Methods
@@ -260,7 +266,6 @@ extension FoodDetailViewController: UITableViewDataSource {
         
         return cell
     }
-    
     
 }
 

--- a/Besteats/FoodModi/Model/FoodModi.swift
+++ b/Besteats/FoodModi/Model/FoodModi.swift
@@ -16,9 +16,7 @@ struct FoodModiModel: Codable {
     init(restaurantName: String,
          menu: String,
          oneLiner: String,
-         type: String
-        )
-    {
+         type: String) {
         self.restaurantName = restaurantName
         self.menu = menu
         self.oneLiner = oneLiner

--- a/Besteats/MainViewController.swift
+++ b/Besteats/MainViewController.swift
@@ -142,10 +142,14 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         let items = restaurantsData
+        let foodDetailVC = FoodDetailViewController(selectedItem: items[indexPath.row].restaurantName, relatedItems: items[indexPath.row])
         
-        let foodDetailVC = FoodDetailViewController(selectedItem: items[indexPath.row].restaurantName)
-        navigationController?.pushViewController(foodDetailVC, animated: true)
-        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        
+        let backBarButtonItem = UIBarButtonItem(title: "",
+                                                style: .plain,
+                                                target: self, action: nil)
+        navigationController?.pushViewController(foodDetailVC,
+                                                 animated: true)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
         


### PR DESCRIPTION
- 상세페이지 -> 추가 버튼시 Foodmodi 페이지 modal로 띄우기
- 맛집이름 데이터 상세페이지에 넘기기, 네비게이션 상단에 클릭된 맛집명 보여주기
- 상세 페이지에 데이터 전체 넘기기 (데이터 구조 수정 필요)